### PR TITLE
feat: enforce password reset for temporary passwords

### DIFF
--- a/src/pages/account/LoginPage.tsx
+++ b/src/pages/account/LoginPage.tsx
@@ -76,7 +76,10 @@ export default function LoginPage() {
     }
 
     if (isTemp) {
-      navigate('/reset-password', { replace: true })
+      navigate('/reset-password', {
+        state: { isTemp: true, tempPassword: getValues('password') },
+        replace: true,
+      })
       return
     }
 

--- a/src/pages/account/LoginPage.tsx
+++ b/src/pages/account/LoginPage.tsx
@@ -76,10 +76,7 @@ export default function LoginPage() {
     }
 
     if (isTemp) {
-      navigate('/reset-password', {
-        state: { isTemp: true, tempPassword: getValues('password') },
-        replace: true,
-      })
+      navigate('/reset-password', { state: { isTemp: true }, replace: true })
       return
     }
 

--- a/src/pages/account/LoginPage.tsx
+++ b/src/pages/account/LoginPage.tsx
@@ -65,6 +65,7 @@ export default function LoginPage() {
     // session fallback so protected routes and E2E auth flows remain stable.
     const refresh_token = authData.refresh_token ?? authData.refreshToken ?? token
     const role = authData.role ?? authData.user?.role
+    const isTemp = authData.is_temp ?? authData.user?.is_temp
 
     if (token && refresh_token) {
       // Read the checkbox value at execution time; avoids stale-closure via getValues
@@ -72,6 +73,11 @@ export default function LoginPage() {
       console.log('Tokens stored successfully')
     } else {
       console.error('Login success but tokens missing in response:', response)
+    }
+
+    if (isTemp) {
+      navigate('/reset-password', { replace: true })
+      return
     }
 
     if (role === 'admin') {

--- a/src/pages/account/ResetPassword.tsx
+++ b/src/pages/account/ResetPassword.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent } from '@/components/ui/card'
 import Header from '@/components/Header'
-import { useResetPassword } from '@/hooks/index'
+import { useResetPassword, useGetUserProfile } from '@/hooks/index'
 import { logout } from '@/lib/auth'
 import { toast } from '@/lib/toast'
 
@@ -24,10 +24,10 @@ export default function ResetPasswordPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
-  const isTemp = location.state?.isTemp || false
-  const tempPassword = location.state?.tempPassword || ''
   const [showPassword, setShowPassword] = useState(false)
 
+  const { data: userProfile, isLoading: isLoadingProfile } = useGetUserProfile()
+  const isTemp = location.state?.isTemp || userProfile?.is_temp || false
   const {
     register,
     handleSubmit,
@@ -57,7 +57,7 @@ export default function ResetPasswordPage() {
 
     try {
       await postResetPassword({
-        old_password: isTemp ? tempPassword : (data.oldPassword || ''),
+        old_password: isTemp ? '' : data.oldPassword || '',
         new_password: data.newPassword,
       })
       toast.success(t('auth.resetPasswordSuccess'))
@@ -91,6 +91,14 @@ export default function ResetPasswordPage() {
         message: t('auth.resetPasswordError'),
       })
     }
+  }
+
+  if (isLoadingProfile) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin" />
+      </div>
+    )
   }
 
   return (

--- a/src/pages/account/ResetPassword.tsx
+++ b/src/pages/account/ResetPassword.tsx
@@ -56,10 +56,12 @@ export default function ResetPasswordPage() {
     }
 
     try {
-      await postResetPassword({
-        old_password: isTemp ? '' : data.oldPassword || '',
+      const payload = {
         new_password: data.newPassword,
-      })
+        ...(isTemp ? {} : { old_password: data.oldPassword || '' }),
+      }
+
+      await postResetPassword(payload as Parameters<typeof postResetPassword>[0])
       toast.success(t('auth.resetPasswordSuccess'))
       logout()
       setTimeout(() => {

--- a/src/pages/account/ResetPassword.tsx
+++ b/src/pages/account/ResetPassword.tsx
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { Lock, Eye, EyeOff, ArrowLeft, Loader2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -15,7 +15,7 @@ import { logout } from '@/lib/auth'
 import { toast } from '@/lib/toast'
 
 interface ResetPasswordData {
-  oldPassword: string
+  oldPassword?: string
   newPassword: string
   confirmNewPassword: string
 }
@@ -23,6 +23,9 @@ interface ResetPasswordData {
 export default function ResetPasswordPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const location = useLocation()
+  const isTemp = location.state?.isTemp || false
+  const tempPassword = location.state?.tempPassword || ''
   const [showPassword, setShowPassword] = useState(false)
 
   const {
@@ -54,7 +57,7 @@ export default function ResetPasswordPage() {
 
     try {
       await postResetPassword({
-        old_password: data.oldPassword,
+        old_password: isTemp ? tempPassword : (data.oldPassword || ''),
         new_password: data.newPassword,
       })
       toast.success(t('auth.resetPasswordSuccess'))
@@ -112,29 +115,31 @@ export default function ResetPasswordPage() {
               className="space-y-6 mt-6"
             >
               {/* Old Password */}
-              <div className="space-y-2">
-                <Label>{t('auth.oldPassword')}</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    data-testid="oldPassword"
-                    type={showPassword ? 'text' : 'password'}
-                    className="pl-10 pr-10"
-                    {...register('oldPassword', {
-                      required: t('auth.oldPasswordRequired'),
-                    })}
-                  />
-                  <PasswordToggle
-                    show={showPassword}
-                    onClick={() => setShowPassword(!showPassword)}
-                  />
+              {!isTemp && (
+                <div className="space-y-2">
+                  <Label>{t('auth.oldPassword')}</Label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-3 w-4 h-4 text-muted-foreground" />
+                    <Input
+                      data-testid="oldPassword"
+                      type={showPassword ? 'text' : 'password'}
+                      className="pl-10 pr-10"
+                      {...register('oldPassword', {
+                        required: !isTemp ? t('auth.oldPasswordRequired') : false,
+                      })}
+                    />
+                    <PasswordToggle
+                      show={showPassword}
+                      onClick={() => setShowPassword(!showPassword)}
+                    />
+                  </div>
+                  {errors.oldPassword && (
+                    <p data-testid="form-error" className="text-sm text-destructive">
+                      {errors.oldPassword.message}
+                    </p>
+                  )}
                 </div>
-                {errors.oldPassword && (
-                  <p data-testid="form-error" className="text-sm text-destructive">
-                    {errors.oldPassword.message}
-                  </p>
-                )}
-              </div>
+              )}
 
               {/* New Password */}
               <div className="space-y-2">

--- a/src/routers/PrivateRoute.tsx
+++ b/src/routers/PrivateRoute.tsx
@@ -27,8 +27,8 @@ const PrivateRoute: React.FC<Props> = ({ children, allowRoles }) => {
     return <Navigate to="/login" replace />;
   }
 
-  if ((data as { is_temp?: boolean })?.is_temp && location.pathname !== '/reset-password') {
-    return <Navigate to="/reset-password" state={{ isTemp: true }} replace />;
+  if (data?.is_temp && location.pathname !== '/reset-password') {
+    return <Navigate to="/reset-password" replace />;
   }
 
   if (allowRoles && (!role || !allowRoles.includes(role))) {

--- a/src/routers/PrivateRoute.tsx
+++ b/src/routers/PrivateRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useGetUserProfile } from "@/hooks/index";
 import { getUserRole, isAuthenticated, logout } from "@/lib/auth";
 
@@ -12,6 +12,7 @@ const PrivateRoute: React.FC<Props> = ({ children, allowRoles }) => {
   const isAuth = isAuthenticated();
   const { data, isLoading, isError } = useGetUserProfile();
   const role = getUserRole();
+  const location = useLocation();
 
   if (!isAuth) {
     return <Navigate to="/login" />;
@@ -24,6 +25,10 @@ const PrivateRoute: React.FC<Props> = ({ children, allowRoles }) => {
   if (isError) {
     logout();
     return <Navigate to="/login" replace />;
+  }
+
+  if ((data as { is_temp?: boolean })?.is_temp && location.pathname !== '/reset-password') {
+    return <Navigate to="/reset-password" state={{ isTemp: true }} replace />;
   }
 
   if (allowRoles && (!role || !allowRoles.includes(role))) {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -151,6 +151,7 @@ export type UserProfileResponse = {
     department: string;
     phone_number: string;
     email: string;
+    is_temp?: boolean;
 };
 
 export interface FileResponse {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -7,7 +7,8 @@ export type LoginResponse = {
     refreshToken?: string;
     expires_in?: number;
     role?: string;
-    user?: { role?: string };
+    is_temp?: boolean;
+    user?: { role?: string; is_temp?: boolean };
     // Wrapped response { data: { ... } }
     data?: {
         token?: string;
@@ -16,7 +17,8 @@ export type LoginResponse = {
         refresh_token?: string;
         refreshToken?: string;
         role?: string;
-        user?: { role?: string };
+        is_temp?: boolean;
+        user?: { role?: string; is_temp?: boolean };
     };
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporary accounts are detected and automatically routed to the password-reset flow on login or when accessing protected pages.

* **UX**
  * Password reset adapts for temporary users: the old-password field is hidden and not required; submission omits old password when not applicable.
  * Shows a centered loading spinner while profile data is fetching to avoid premature form rendering.

* **Bug Fixes**
  * Prevents role-based redirects for temporary accounts until password reset completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->