### PR TITLE
feat: separate read status for admin and researcher

### DIFF
--- a/src/components/notifications/NotificationIcon.tsx
+++ b/src/components/notifications/NotificationIcon.tsx
@@ -35,7 +35,7 @@ export function NotificationIcon() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-    const role = getUserRole();
+    const role = getUserRole()?.toLowerCase();
     const notifications =
         data?.data.map((notif) => ({
             ...notif,
@@ -86,8 +86,6 @@ export function NotificationIcon() {
                     <NotificationOverlay
                         notifications={notifications}
                         loading={isLoading}
-                        error={showError}
-                        onRetry={refetch}
                         onNotificationClick={handleNotificationClick}
                         onMarkAllAsRead={() => markAllAsRead()}
                     />

--- a/src/components/notifications/NotificationIcon.tsx
+++ b/src/components/notifications/NotificationIcon.tsx
@@ -12,8 +12,9 @@ import { Badge } from "@/components/ui/badge";
 import { useGetAppointmentNotifications, useMarkAppointmentNotificationAsRead, useMarkAllAppointmentNotificationsAsRead } from "@/hooks/index";
 import { NotificationOverlay } from "./NotificationOverlay";
 import { AppointmentModal } from "./AppointmentModal";
-import { AppointmentResponse } from "@/types/type";
+import type { AppointmentResponse } from "@/types/type";
 import { toast } from "@/lib/toast";
+import { getUserRole } from "@/lib/auth";
 
 export function NotificationIcon() {
     const { t } = useTranslation();
@@ -34,10 +35,17 @@ export function NotificationIcon() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-    const notifications = data?.data || [];
+    const role = getUserRole();
+    const notifications =
+        data?.data.map((notif) => ({
+            ...notif,
+            is_read: role === "admin" ? notif.is_read_admin : notif.is_read_researcher,
+        })) || [];
     const unreadCount = data?.unread_count ?? 0;
 
-    const handleNotificationClick = (notif: AppointmentResponse) => {
+    const handleNotificationClick = (
+        notif: AppointmentResponse & { is_read: boolean }
+    ) => {
         setSelectedAppointment(notif);
         setIsModalOpen(true);
         setIsPopoverOpen(false); // Close dropdown when opening modal

--- a/src/components/notifications/NotificationOverlay.tsx
+++ b/src/components/notifications/NotificationOverlay.tsx
@@ -6,10 +6,12 @@ import { format, isValid } from "date-fns";
 import { th } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 
+type ProcessedNotification = AppointmentResponse & { is_read: boolean };
+
 interface NotificationOverlayProps {
-    notifications: AppointmentResponse[];
+    notifications: ProcessedNotification[];
     loading?: boolean;
-    onNotificationClick: (notification: AppointmentResponse) => void;
+    onNotificationClick: (notification: ProcessedNotification) => void;
     onMarkAllAsRead?: () => void;
 }
 

--- a/src/hooks/notification/patch/useMarkAllAppointmentNotificationsAsRead.ts
+++ b/src/hooks/notification/patch/useMarkAllAppointmentNotificationsAsRead.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiQueryClient } from "@/hooks/client/ApiQueryClient";
-import { NotificationListResponse } from "@/types/type";
+import { NotificationListResponse, AppointmentResponse } from "@/types/type";
+import { getUserRole } from "@/lib/auth";
 
 export const useMarkAllAppointmentNotificationsAsRead = () => {
     const apiQueryClient = new ApiQueryClient(
@@ -20,12 +21,15 @@ export const useMarkAllAppointmentNotificationsAsRead = () => {
 
             // Optimistically update to the new value
             if (previousNotifications) {
+                const role = getUserRole()?.toLowerCase();
+                const readKey = (role === "admin" ? "is_read_admin" : "is_read_researcher") as keyof AppointmentResponse;
+
                 queryClient.setQueryData<NotificationListResponse>(
                     ["getAppointmentNotifications"],
                     {
                         ...previousNotifications,
                         unread_count: 0,
-                        data: previousNotifications.data.map((notif) => ({ ...notif, is_read: true }))
+                        data: previousNotifications.data.map((notif) => ({ ...notif, [readKey]: true }))
                     }
                 );
             }

--- a/src/hooks/notification/patch/useMarkAllAppointmentNotificationsAsRead.ts
+++ b/src/hooks/notification/patch/useMarkAllAppointmentNotificationsAsRead.ts
@@ -22,7 +22,16 @@ export const useMarkAllAppointmentNotificationsAsRead = () => {
             // Optimistically update to the new value
             if (previousNotifications) {
                 const role = getUserRole()?.toLowerCase();
-                const readKey = (role === "admin" ? "is_read_admin" : "is_read_researcher") as keyof AppointmentResponse;
+                const readKey =
+                    role === "admin"
+                        ? "is_read_admin"
+                        : role === "researcher"
+                          ? "is_read_researcher"
+                          : null;
+
+                if (!readKey) {
+                    return { previousNotifications };
+                }
 
                 queryClient.setQueryData<NotificationListResponse>(
                     ["getAppointmentNotifications"],

--- a/src/hooks/notification/patch/useMarkAppointmentNotificationAsRead.ts
+++ b/src/hooks/notification/patch/useMarkAppointmentNotificationAsRead.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiQueryClient } from "@/hooks/client/ApiQueryClient";
-import { NotificationListResponse } from "@/types/type";
+import { NotificationListResponse, AppointmentResponse } from "@/types/type";
+import { getUserRole } from "@/lib/auth";
 
 export const useMarkAppointmentNotificationAsRead = () => {
     const apiQueryClient = new ApiQueryClient(
@@ -20,14 +21,20 @@ export const useMarkAppointmentNotificationAsRead = () => {
 
             // Optimistically update to the new value
             if (previousNotifications) {
-                const isCurrentlyUnread = previousNotifications.data.find(n => n.id === id)?.is_read === false;
-                
+                const role = getUserRole()?.toLowerCase();
+                const readKey = (role === "admin" ? "is_read_admin" : "is_read_researcher") as keyof AppointmentResponse;
+
+                const isCurrentlyUnread =
+                    previousNotifications.data.find(n => n.id === id)?.[readKey] === false;
+
                 queryClient.setQueryData<NotificationListResponse>(
                     ["getAppointmentNotifications"],
                     {
                         ...previousNotifications,
                         unread_count: isCurrentlyUnread ? Math.max(0, previousNotifications.unread_count - 1) : previousNotifications.unread_count,
-                        data: previousNotifications.data.map((notif) => notif.id === id ? { ...notif, is_read: true } : notif)
+                        data: previousNotifications.data.map((notif) =>
+                            notif.id === id ? { ...notif, [readKey]: true } : notif
+                        )
                     }
                 );
             }

--- a/src/hooks/notification/patch/useMarkAppointmentNotificationAsRead.ts
+++ b/src/hooks/notification/patch/useMarkAppointmentNotificationAsRead.ts
@@ -22,7 +22,16 @@ export const useMarkAppointmentNotificationAsRead = () => {
             // Optimistically update to the new value
             if (previousNotifications) {
                 const role = getUserRole()?.toLowerCase();
-                const readKey = (role === "admin" ? "is_read_admin" : "is_read_researcher") as keyof AppointmentResponse;
+                const readKey =
+                    role === "admin"
+                        ? "is_read_admin"
+                        : role === "researcher"
+                          ? "is_read_researcher"
+                          : null;
+
+                if (!readKey) {
+                    return { previousNotifications };
+                }
 
                 const isCurrentlyUnread =
                     previousNotifications.data.find(n => n.id === id)?.[readKey] === false;

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -91,7 +91,8 @@ export type AppointmentResponse = {
     location: string;
     detail: string;
     summary: string;
-    is_read: boolean;
+    is_read_admin: boolean;
+    is_read_researcher: boolean;
     is_notify: boolean;
     created_at: string;
     updated_at: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now track read/unread separately per user role, fixing cross-role read state leakage and ensuring accurate unread counts.

* **Refactor**
  * Notification UI and handlers normalized so read status is consistent per role; click and marking actions now reflect each user's correct notification state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->